### PR TITLE
add versionFunctions to serverless.yml

### DIFF
--- a/services/database/serverless.yml
+++ b/services/database/serverless.yml
@@ -22,6 +22,7 @@ provider:
   name: aws
   runtime: nodejs12.x
   region: us-east-1
+  versionFunctions: true
 
 resources:
   Resources:


### PR DESCRIPTION
The original PR to seed the database with tables merged but received an error described here: https://github.com/CMSgov/cms-mdct-seds/actions/runs/466967156

This PR is attempting the resolution described here: https://github.com/davidgf/serverless-plugin-canary-deployments/issues/38
"The versionFunctions serverless parameter was set to false because we ran out of lambda storage and we weren't really rolling back using the versions anyway.
So, if anyone else runs into this problem, it could be that function versioning is off. Turning it back on would fix it."

From @sethsacher: "Best thing coming up is versionFunctions is set to false and should be set to true instead. We aren’t explicitly setting it to false, so perhaps this is occurring."

For placement, I referenced this: https://www.serverless.com/framework/docs/providers/aws/guide/functions/