### PR TITLE
change resources: policies: Resource to reference table Arns instead …

### DIFF
--- a/services/app-api/serverless.yml
+++ b/services/app-api/serverless.yml
@@ -165,13 +165,13 @@ resources:
                   - dynamodb:UpdateItem
                   - dynamodb:DeleteItem
                 Resource:
-                  - ${self:custom.AgeRangesTableName}
-                  - ${self:custom.FormAnswersTableName}
-                  - ${self:custom.FormQuestionsTableName}
-                  - ${self:custom.FormsTableName}
-                  - ${self:custom.StateFormsTableName}
-                  - ${self:custom.StatesTableName}
-                  - ${self:custom.StatusTableName}
+                  - ${self:custom.AgeRangesTableArn}
+                  - ${self:custom.FormAnswersTableArn}
+                  - ${self:custom.FormQuestionsTableArn}
+                  - ${self:custom.FormsTableArn}
+                  - ${self:custom.StateFormsTableArn}
+                  - ${self:custom.StatesTableArn}
+                  - ${self:custom.StatusTableArn}
               - Effect: 'Allow'
                 Action:
                   - logs:CreateLogStream


### PR DESCRIPTION
…of tables

more efforts to fix the merge deploy failure

`Serverless: Operation failed!
Serverless: View the full error output: https://***.console.aws.amazon.com/cloudformation/home?region=***#/stack/detail?stackId=arn%3Aaws%3Acloudformation%3A***%3A760820259496%3Astack%2Fapp-api-localdev%2F3b2ae3c0-4532-11eb-b647-1221171ce649
 
  Serverless Error ---------------------------------------
 
  An error occurred: LambdaApiRole - Resource localdev-age-ranges must be in ARN format or "*". (Service: AmazonIdentityManagement; Status Code: 400; Error Code: MalformedPolicyDocument; Request ID: 1a1e90f8-6078-425d-ab1a-e151f374e3b1; Proxy: null).`