### PR TITLE
change structure of all tables to be 1 attribute per table (part 1 of fix)

### DIFF
--- a/services/database/serverless.yml
+++ b/services/database/serverless.yml
@@ -33,52 +33,40 @@ resources:
     AgeRangesTable:
       Type: AWS::DynamoDB::Table
       Properties:
-        TableName: ${self:custom.stage}-age-ranges
+        TableName: ${self:custom.stage}-age-ranges1
         AttributeDefinitions:
-          - AttributeName: age_range_id
-            AttributeType: N
           - AttributeName: age_range
             AttributeType: S
         KeySchema:
-          - AttributeName: age_range_id
-            KeyType: HASH
           - AttributeName: age_range
-            KeyType: RANGE
+            KeyType: HASH
         BillingMode: PAY_PER_REQUEST # Set the capacity to auto-scale
     FormAnswersTable:
       Type: AWS::DynamoDB::Table
       Properties:
-        TableName: ${self:custom.stage}-form-answers
+        TableName: ${self:custom.stage}-form-answers1
         AttributeDefinitions:
-          - AttributeName: answer_id
-            AttributeType: N
           - AttributeName: answer_entry
             AttributeType: S
         KeySchema:
-          - AttributeName: answer_id
-            KeyType: HASH
           - AttributeName: answer_entry
-            KeyType: RANGE
+            KeyType: HASH
         BillingMode: PAY_PER_REQUEST # Set the capacity to auto-scale
     FormQuestionsTable:
       Type: AWS::DynamoDB::Table
       Properties:
-        TableName: ${self:custom.stage}-form-questions
+        TableName: ${self:custom.stage}-form-questions1
         AttributeDefinitions:
-          - AttributeName: question_id
-            AttributeType: N
           - AttributeName: question
             AttributeType: S
         KeySchema:
-          - AttributeName: question_id
-            KeyType: HASH
           - AttributeName: question
-            KeyType: RANGE
+            KeyType: HASH
         BillingMode: PAY_PER_REQUEST # Set the capacity to auto-scale
     FormsTable:
       Type: AWS::DynamoDB::Table
       Properties:
-        TableName: ${self:custom.stage}-forms
+        TableName: ${self:custom.stage}-forms1
         AttributeDefinitions:
           - AttributeName: form
             AttributeType: S
@@ -89,49 +77,37 @@ resources:
     StateFormsTable:
       Type: AWS::DynamoDB::Table
       Properties:
-        TableName: ${self:custom.stage}-state-forms
+        TableName: ${self:custom.stage}-state-forms1
         StreamSpecification:
           StreamViewType: NEW_AND_OLD_IMAGES
         AttributeDefinitions:
-          - AttributeName: state_form_id
-            AttributeType: N
           - AttributeName: state_form
             AttributeType: S
         KeySchema:
-          - AttributeName: state_form_id
-            KeyType: HASH
           - AttributeName: state_form
-            KeyType: RANGE
+            KeyType: HASH
         BillingMode: PAY_PER_REQUEST # Set the capacity to auto-scale
     StatesTable:
       Type: AWS::DynamoDB::Table
       Properties:
-        TableName: ${self:custom.stage}-states
+        TableName: ${self:custom.stage}-states1
         AttributeDefinitions:
           - AttributeName: state_id
-            AttributeType: N
-          - AttributeName: state_name
             AttributeType: S
         KeySchema:
           - AttributeName: state_id
             KeyType: HASH
-          - AttributeName: state_name
-            KeyType: RANGE
         BillingMode: PAY_PER_REQUEST # Set the capacity to auto-scale
     StatusTable:
       Type: AWS::DynamoDB::Table
       Properties:
-        TableName: ${self:custom.stage}-status
+        TableName: ${self:custom.stage}-status1
         AttributeDefinitions:
-          - AttributeName: status_id
-            AttributeType: N
           - AttributeName: status
             AttributeType: S
         KeySchema:
-          - AttributeName: status_id
-            KeyType: HASH
           - AttributeName: status
-            KeyType: RANGE
+            KeyType: HASH
         BillingMode: PAY_PER_REQUEST # Set the capacity to auto-scale
   Outputs:
     AgeRangesTableName:


### PR DESCRIPTION
Error Message
XXXXXXXX - CloudFormation cannot update a stack when a custom-named resource requires replacing. Rename xxxxxx-dev and update the stack again.
Problem
You’ve made some changes to a resource, and CloudFormation needs to replace the resource by removing and recreating it. However, CloudFormation cannot replace a resource that has a custom name.

Solution
To get around this limitation, you have to rename the resource in your serverless.yml, deploy it, and rename it back.

Let’s say the resource is called usersTable-dev, rename it to usersTable2-dev and deploy.

After the deployment succeeds, you can rename the resource back to usersTable-dev and continue deploying.

Important: If the resource you are renaming is a DynamoDB table, renaming it will drop all the data. Make sure to back up the table data before renaming and redeploying.


https://seed.run/docs/serverless-errors/cloudformation-cannot-update-a-stack-when-a-custom-named-resource-requires-replacing.html