### PR TITLE
Revert tableName variable naming in generic api handlers

### DIFF
--- a/services/app-api/handlers/create.js
+++ b/services/app-api/handlers/create.js
@@ -19,7 +19,7 @@ export const main = handler(async (event, context) => {
     });
 
   const params = {
-    TableName: process.env.AuthUserTableName,
+    TableName: process.env.tableName,
     Item: {
       userId: event.requestContext.identity.cognitoIdentityId,
       amendmentId: uuid.v1(),

--- a/services/app-api/handlers/delete.js
+++ b/services/app-api/handlers/delete.js
@@ -9,7 +9,7 @@ export const main = handler(async (event, context) => {
   }
 
   const params = {
-    TableName: process.env.AuthUserTableName,
+    TableName: process.env.tableName,
     // 'Key' defines the partition key and sort key of the item to be removed
     // - 'userId': Identity Pool identity id of the authenticated user
     // - 'amendmentId': path parameter

--- a/services/app-api/handlers/get.js
+++ b/services/app-api/handlers/get.js
@@ -9,7 +9,7 @@ export const main = handler(async (event, context) => {
   }
 
   const params = {
-    TableName: process.env.AuthUserTableName,
+    TableName: process.env.tableName,
     // 'Key' defines the partition key and sort key of the item to be retrieved
     // - 'userId': Identity Pool identity id of the authenticated user
     // - 'amendmentId': path parameter

--- a/services/app-api/handlers/list.js
+++ b/services/app-api/handlers/list.js
@@ -8,7 +8,7 @@ export const main = handler(async (event, context) => {
     return null;
   }
   const params = {
-    TableName: process.env.AuthUserTableName,
+    TableName: process.env.tableName,
     // 'KeyConditionExpression' defines the condition for the query
     // - 'userId = :userId': only return items with matching 'userId'
     //   partition key

--- a/services/app-api/handlers/update.js
+++ b/services/app-api/handlers/update.js
@@ -9,7 +9,7 @@ export const main = handler(async (event, context) => {
   }
   const data = JSON.parse(event.body);
   const params = {
-    TableName: process.env.AuthUserTableName,
+    TableName: process.env.tableName,
     // 'Key' defines the partition key and sort key of the item to be updated
     // - 'userId': Identity Pool identity id of the authenticated user
     // - 'amendmentId': path parameter


### PR DESCRIPTION
changed these unnecessarily while trying to resolve 500 error on Users api - changing them back now