### PR TITLE
Feature: Add handler organizing convention to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,12 @@ functions:
 ```
 
 2. Create handler in `{ROOT}/services/app-api/handlers`
-   1. Note: For Table name use process.env vars located in `{ROOT}/.env`
+   1. Note: For Table name use custom vars located in `{ROOT}/services/app-api/serverless.yml`
+   2. Conventions:
+      1. Each file in the handler directory should contain a single function called 'main'
+      2. The handlers are organized by API, each with their own folder. Within those folders should be separate files for each HTTP verb.
+         For instance: There might be `users` folder in handlers, (`app-api/handlers/users`). Within that `users`folder would be individual files each corresponding with an HTTP verb so that the inside of `users` might look like `get.js` `create.js` `update.js` `delete.js`, etc.
+         The intention of this structure is that each of the verbs within a folder corresponds to the same data set in the database.
 3. Add wrapper function in `{ROOT}/services/ui-src/src/lib/api.js`
    example:
 


### PR DESCRIPTION
**Linked Issue:**
None, this came about after a group discussion with the dev team. 

**Overview:**
We decided to structure our handlers in such a way that each folder names a _type_ of API and the files within it correspond to an HTTP verb and contain only one function. This was done so that our handlers dont become confusing as our API grows. Previously similar/related handlers were together in folders (ie: get-single-form and get-list-of-forms), but as the need for more verbs grows folders like that could quickly become messy. The solution we reached was to give handlers such as those their own folders and the only thing each folder would contain is files named after HTTP verbs, each with only one function (called main). 

**Files changed (1):**
`README.md`
The README has been updated to reflect the handler naming conventions we agreed on so that our API structure is easy to read and so that we move forward uniformly 