### PR TITLE
add the other table ARNs to LambdaApoRole

### DIFF
--- a/services/app-api/serverless.yml
+++ b/services/app-api/serverless.yml
@@ -274,7 +274,7 @@ resources:
                     - ${self:custom.StatesTableArn}
                     - ${self:custom.StatusTableArn}
                     - ${self:custom.AuthUserTableArn}
-                    - ${self:custom.AuthUserRolesTableArn}                    
+                    - ${self:custom.AuthUserRolesTableArn}
                     - ${self:custom.AuthJobCodesTableArn}
                     - ${self:custom.AuthUserStatesTableArn}
                 - Effect: "Allow"

--- a/services/app-api/serverless.yml
+++ b/services/app-api/serverless.yml
@@ -274,6 +274,9 @@ resources:
                     - ${self:custom.StatesTableArn}
                     - ${self:custom.StatusTableArn}
                     - ${self:custom.AuthUserTableArn}
+                    - ${self:custom.AuthUserRolesTableArn}                    
+                    - ${self:custom.AuthJobCodesTableArn}
+                    - ${self:custom.AuthUserStatesTableArn}
                 - Effect: "Allow"
                   Action:
                     - logs:CreateLogStream


### PR DESCRIPTION
So we don't run into this issue if we try to scan any other tables that exist:

- AuthUserRolesTableArn
- AuthJobCodesTableArn
- AuthUserStatesTableArn