### PR TITLE
Style checks

### DIFF
--- a/.github/workflows/style_checks.yml
+++ b/.github/workflows/style_checks.yml
@@ -4,13 +4,14 @@ on: [pull_request]
 
 jobs:
   prettier:
-    name: prettier has been run on compatible files
     runs-on: ubuntu-latest
-    container: node:14
     steps:
-      - uses: actions/checkout@v2
-      - name: check that modified files are prettier
-        run: npx prettier $(git diff --diff-filter=ACMR --name-only --relative origin/master -- | xargs) -c -u .
+      - uses: actions/checkout@v1
+      - uses: actions/setup-node@v1
+        with:
+          node-version: "12.x"
+      - name: check prettier
+        run: npx prettier . -c -u
   eslint:
     name: frontend linting
     runs-on: ubuntu-latest

--- a/.github/workflows/style_checks.yml
+++ b/.github/workflows/style_checks.yml
@@ -6,8 +6,8 @@ jobs:
   prettier:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
         with:
           node-version: "12.x"
       - name: check prettier

--- a/.github/workflows/style_checks.yml
+++ b/.github/workflows/style_checks.yml
@@ -11,7 +11,7 @@ jobs:
         with:
           node-version: "12.x"
       - name: check prettier
-        run: npx prettier . -c -u
+        run: npx prettier --write .
   eslint:
     name: frontend linting
     runs-on: ubuntu-latest

--- a/.github/workflows/style_checks.yml
+++ b/.github/workflows/style_checks.yml
@@ -11,7 +11,7 @@ jobs:
         with:
           node-version: "12.x"
       - name: check prettier
-        run: npx prettier --write .
+        run: npx prettier $(git diff --diff-filter=ACMR --name-only --relative origin/master -- | xargs) -c -u .
   eslint:
     name: frontend linting
     runs-on: ubuntu-latest

--- a/.github/workflows/style_checks.yml
+++ b/.github/workflows/style_checks.yml
@@ -11,7 +11,7 @@ jobs:
         with:
           node-version: "12.x"
       - name: check prettier
-        run: npx prettier $(git diff --diff-filter=ACMR --name-only --relative origin/master -- | xargs) -c -u .
+        run: npx prettier --write .
   eslint:
     name: frontend linting
     runs-on: ubuntu-latest


### PR DESCRIPTION
just updated a few things in here so prettier runs the correct way. this is part of the pull from quickstart, they are using actions/checkout@v1 and actions/checkout@v1 but i also bumped ours to v2 because the v2 release adds reliability for pulling node distributions from a cache of node releases.




 