### PR TITLE
Skipci add code climate badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Welcome to the Centers for Medicare & Medicaid MACPro Data Collection Tool (MDCT) CHIP Statistical Enrollment Data System (SEDS). MDCT SEDS is a serverless form submission application built and deployed to AWS within the Serverless Application Framwork. Is it based on:
 
-[macpro-quickstart-serverless](https://github.com/CMSgov/macpro-quickstart-serverless) ![Build](https://github.com/CMSgov/macpro-quickstart-serverless/workflows/Build/badge.svg?branch=master)[![latest release](https://img.shields.io/github/release/cmsgov/macpro-quickstart-serverless.svg)](https://github.com/cmsgov/macpro-quickstart-serverless/releases/latest)
+[cms-mdct-seds](https://github.com/CMSgov/cms-mdct-seds) [![Maintainability](https://api.codeclimate.com/v1/badges/df4bb29388dee162e0e5/maintainability)](https://codeclimate.com/github/CMSgov/cms-mdct-seds/maintainability)
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
+[cms-mdct-seds](https://github.com/CMSgov/cms-mdct-seds) [![Maintainability](https://api.codeclimate.com/v1/badges/df4bb29388dee162e0e5/maintainability)](https://codeclimate.com/github/CMSgov/cms-mdct-seds/maintainability)
+
 # MACPro Data Collection Tool: CHIP Statistical Enrollment Data System
 
 Welcome to the Centers for Medicare & Medicaid MACPro Data Collection Tool (MDCT) CHIP Statistical Enrollment Data System (SEDS). MDCT SEDS is a serverless form submission application built and deployed to AWS within the Serverless Application Framwork. Is it based on:
-
-[cms-mdct-seds](https://github.com/CMSgov/cms-mdct-seds) [![Maintainability](https://api.codeclimate.com/v1/badges/df4bb29388dee162e0e5/maintainability)](https://codeclimate.com/github/CMSgov/cms-mdct-seds/maintainability)
 
 ## Architecture
 


### PR DESCRIPTION
The purpose of this PR is to add in a maintainability build badge to the cms-mdct-seds repository. The badge is located within the README.md and is pointing to the main integration branch which is master. Clicking on the badge itself will take an individual out to code climate in which they can investigate all identified issues. 

For more on code climate maintainability please reference :
https://docs.codeclimate.com/docs/maintainability