### PR TITLE
Correct logic when checking for roles

### DIFF
--- a/services/ui-src/src/App.js
+++ b/services/ui-src/src/App.js
@@ -125,10 +125,12 @@ function App() {
       return role;
     }
 
-    if (role.includes("CHIP_D_USER_GROUP_ADMIN")) {
-      return "admin";
-    } else if (role.includes("CHIP_D_USER_GROUP")) {
-      return "state";
+    if (role) {
+      if (role.includes("CHIP_D_USER_GROUP_ADMIN")) {
+        return "admin";
+      } else if (role.includes("CHIP_D_USER_GROUP")) {
+        return "state";
+      }
     } else {
       return null;
     }


### PR DESCRIPTION
Roles was previously checking with an includes check, which failed if role is null. This checks for null first.