### PR TITLE
Hotfix quarterly router

### DIFF
--- a/services/ui-src/src/components/form/FormPage.js
+++ b/services/ui-src/src/components/form/FormPage.js
@@ -17,7 +17,7 @@ const FormPage = ({ getForm, statusData }) => {
   // format URL parameters to compensate for human error:  /forms/AL/2021/01/21E === forms/al/2021/1/21e
   const formattedStateName = state.toUpperCase();
   const quarterInt = Number.parseInt(quarter).toString();
-  const formattedFormName = formName.toUpperCase();
+  const formattedFormName = formName.toUpperCase().replace("-", ".");
 
   // Call the API and set questions, answers and status data in redux based on URL parameters
   useEffect(() => {

--- a/services/ui-src/src/containers/Quarterly.js
+++ b/services/ui-src/src/containers/Quarterly.js
@@ -31,7 +31,7 @@ const Quarterly = () => {
     let urlSegment;
     switch (formName) {
       case "GRE":
-        urlSegment = "gre";
+        urlSegment = "GRE";
         break;
       case "64.EC":
         urlSegment = "64-EC";

--- a/services/ui-src/src/containers/Quarterly.js
+++ b/services/ui-src/src/containers/Quarterly.js
@@ -34,19 +34,19 @@ const Quarterly = () => {
         urlSegment = "gre";
         break;
       case "64.EC":
-        urlSegment = "64ec";
+        urlSegment = "64-EC";
         break;
       case "64.ECI":
-        urlSegment = "64eci";
+        urlSegment = "64-ECI";
         break;
       case "64.21E":
-        urlSegment = "64-21e";
+        urlSegment = "64-21E";
         break;
-      case "64.21EI":
-        urlSegment = "64-21ei";
+      case "21E":
+        urlSegment = "21E";
         break;
-      case "21E": // may need to update all of the case statements
-        urlSegment = "21e";
+      case "21PW":
+        urlSegment = "21PW";
         break;
       default:
         urlSegment = false;


### PR DESCRIPTION
Replaces PR #168 
Developer: Alexis Woodbury

Linked Issue:
None, hotfix.

Overview:
The router on the quarterly page was not providing the correct URL and was missing 21PW. Form page added an additional step to formatting.

Files Changed (2):
services/ui-src/src/components/form/FormPage.js
Form page can now take in a URL with hyphens and replaces them with periods. Its best for the URL segments to not have periods in them so they're being sent from Quarterly.js as "/forms/AL/2021/1/64-21E". Form page is replacing the hyphen in the URL with a period before fetching the form.

services/ui-src/src/containers/Quarterly.js
21PW is added to the list of possible forms. 64-21ei removed because that form doesnt exist.
All url segments have been formatted to match form names except that instead of periods there are hyphens.

Notes: This should not be merged until PR #161 is merged because it is forked from that branch.