### PR TITLE
Add Age Range to GRE Form

### DIFF
--- a/src/database/initial_data_load/age_ranges.json
+++ b/src/database/initial_data_load/age_ranges.json
@@ -28,5 +28,10 @@
     "ageRange": "Ages 19 - 64",
     "ageDescription": "Age 19 years through age 64 years",
     "rangeId": "1964"
+  },
+  {
+    "ageRange": "Ages 0 - 18",
+    "ageDescription": "Conception through age 18 years",
+    "rangeId": "0018"
   }
 ]

--- a/src/database/initial_data_load/form_answers_GRE_AL.json
+++ b/src/database/initial_data_load/form_answers_GRE_AL.json
@@ -1,8 +1,10 @@
 [
   {
-    "answer_entry": "AL-2021-1-GRE-01",
+    "answer_entry": "AL-2021-1-GRE-0018-01",
     "state_form": "AL-2021-1-GRE",
     "question": "2021-GRE-01",
+    "age_range": "All Ages",
+    "rangeId": "0018",
     "rows": [
       {
         "col1": "",
@@ -43,9 +45,11 @@
     "created_by": "seed"
   },
   {
-    "answer_entry": "AL-2021-1-GRE-02",
+    "answer_entry": "AL-2021-1-GRE-0018-02",
     "state_form": "AL-2021-1-GRE",
     "question": "2021-GRE-02",
+    "age_range": "All Ages",
+    "rangeId": "0018",
     "rows": [
       {
         "col1": "",
@@ -214,9 +218,11 @@
     "created_by": "seed"
   },
   {
-    "answer_entry": "AL-2021-1-GRE-03",
+    "answer_entry": "AL-2021-1-GRE-0018-03",
     "state_form": "AL-2021-1-GRE",
     "question": "2021-GRE-03",
+    "age_range": "All Ages",
+    "rangeId": "0018",
     "rows": [
       {
         "col1": "",

--- a/src/database/initial_data_load/form_answers_GRE_MD.json
+++ b/src/database/initial_data_load/form_answers_GRE_MD.json
@@ -1,8 +1,10 @@
 [
   {
-    "answer_entry": "MD-2021-1-GRE-01",
+    "answer_entry": "MD-2021-1-GRE-0018-01",
     "state_form": "MD-2021-1-GRE",
     "question": "2021-GRE-01",
+    "age_range": "All Ages",
+    "rangeId": "0018",
     "rows": [
       {
         "col1": "",
@@ -43,9 +45,11 @@
     "created_by": "seed"
   },
   {
-    "answer_entry": "MD-2021-1-GRE-02",
+    "answer_entry": "MD-2021-1-GRE-0018-02",
     "state_form": "MD-2021-1-GRE",
     "question": "2021-GRE-02",
+    "age_range": "All Ages",
+    "rangeId": "0018",
     "rows": [
       {
         "col1": "",
@@ -214,9 +218,11 @@
     "created_by": "seed"
   },
   {
-    "answer_entry": "MD-2021-1-GRE-03",
+    "answer_entry": "MD-2021-1-GRE-0018-03",
     "state_form": "MD-2021-1-GRE",
     "question": "2021-GRE-03",
+    "age_range": "All Ages",
+    "rangeId": "0018",
     "rows": [
       {
         "col1": "",

--- a/src/database/initial_data_load/form_answers_GRE_PA.json
+++ b/src/database/initial_data_load/form_answers_GRE_PA.json
@@ -1,8 +1,10 @@
 [
   {
-    "answer_entry": "PA-2021-1-GRE-01",
+    "answer_entry": "PA-2021-1-GRE-0018-01",
     "state_form": "PA-2021-1-GRE",
     "question": "2021-GRE-01",
+    "age_range": "All Ages",
+    "rangeId": "0018",
     "rows": [
       {
         "col1": "",
@@ -43,9 +45,11 @@
     "created_by": "seed"
   },
   {
-    "answer_entry": "PA-2021-1-GRE-02",
+    "answer_entry": "PA-2021-1-GRE-0018-02",
     "state_form": "PA-2021-1-GRE",
     "question": "2021-GRE-02",
+    "age_range": "All Ages",
+    "rangeId": "0018",
     "rows": [
       {
         "col1": "",
@@ -214,9 +218,11 @@
     "created_by": "seed"
   },
   {
-    "answer_entry": "PA-2021-1-GRE-03",
+    "answer_entry": "PA-2021-1-GRE-0018-03",
     "state_form": "PA-2021-1-GRE",
     "question": "2021-GRE-03",
+    "age_range": "All Ages",
+    "rangeId": "0018",
     "rows": [
       {
         "col1": "",


### PR DESCRIPTION
**Purpose**
The GRE form does not have an ageRange specified in it because it applies to all children (it is a summary form). So to allow the form to generate using the current tab structure (which is dynamically created based on the presence of an ageRange), the changes to the JSON here add a new ageRange (0 -18) to the age-ranges table and edits the GRE answers for the test states (AL, MD & PA) to include the new (all encompassing) age range.

**Files Edited**
- age_ranges.json
- form_answers_GRE_AL.json
- form_answers_GRE_MD.json
- form_answers_GRE_PA.json